### PR TITLE
fix: resolve missing seed images in Docker container

### DIFF
--- a/WeNeed1/WeNeed1/Dockerfile
+++ b/WeNeed1/WeNeed1/Dockerfile
@@ -19,4 +19,9 @@ RUN dotnet publish "WeNeed1.csproj" -c Release -o /app/publish /p:UseAppHost=fal
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
+COPY WeNeed1/profilePictureSeed.png /app/
+COPY WeNeed1/sportCenterImageSeed.jpg /app/
+COPY WeNeed1/sportFieldSeedImage.jpg /app/
+COPY WeNeed1/teamPictureSeed.jpg /app/
+
 ENTRYPOINT ["dotnet", "WeNeed1.dll"]


### PR DESCRIPTION
- Added correct file paths for COPY commands in Dockerfile to include 'WeNeed1/' prefix
- Fixed FileNotFoundException for seed images (profilePictureSeed.png, sportCenterImageSeed.jpg, sportFieldSeedImage.jpg, teamPictureSeed.jpg)
- Images are now properly copied from build context to container /app/ directory
- Resolves application crash on startup during image seeding process